### PR TITLE
Fix the default-non-apparmor on hosts without apparmor

### DIFF
--- a/PodSecurityPolicies/default-non-apparmor.psp.yaml
+++ b/PodSecurityPolicies/default-non-apparmor.psp.yaml
@@ -5,9 +5,7 @@ metadata:
   name: default
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
 spec:
   privileged: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
With these annotations on hosts without AppArmor, pods will be blocked
with the error "Cannot enforce AppArmor: AppArmor is not enabled on the
host". Removing them resolves the issue.

https://ibm.github.io/event-streams/2018.3.1/troubleshooting/pods-apparmor-blocked/